### PR TITLE
Add missing include unistd.h to ada_fuzz_header.h

### DIFF
--- a/lang/c/ada_fuzz_header.h
+++ b/lang/c/ada_fuzz_header.h
@@ -4,6 +4,8 @@
  * 
 */
 
+#include <unistd.h>
+
 // Simple garbage collector 
 #define GB_SIZE 100
 


### PR DESCRIPTION
This is required, due to the use of `unlink`.

Otherwise, compilers such as clang-16 (or later) will spit out a warning:

```
/src/fuzz-headers/lang/c/ada_fuzz_header.h:159:5: error: call to undeclared function 'unlink'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  159 |     unlink(filename2);
      |     ^
